### PR TITLE
 Amended beanspeak exceptions and tests

### DIFF
--- a/.ci/after-success.sh
+++ b/.ci/after-success.sh
@@ -12,22 +12,20 @@ PROJECT_ROOT=$(readlink -enq "$(dirname $0)/../")
 if [ "${REPORT_COVERAGE}" = "1" ]; then
 	output=${PROJECT_ROOT}/coverage.info
 
-	lcov --no-checksum --directory ${PROJECT_ROOT}/beanspeak --directory ${PROJECT_ROOT} --capture --compat-libtool --output-file ${output}
-
-	lcov --remove ${output} "/usr*" \
-		--remove ${output} "*/.phpenv/*" \
-		--remove ${output} "/home/travis/build/include/*" \
+	lcov --no-checksum \
+		--directory ${PROJECT_ROOT}/beanspeak \
+		--directory ${PROJECT_ROOT} \
+		--capture \
 		--compat-libtool \
 		--output-file ${output}
 
-	coveralls-lcov ${output}
-fi
+	lcov --remove ${output} "/usr*" \
+		--remove ${output} "*/.phpenv/*" \
+		--remove ${output} "${HOME}/build/include/*" \
+		--compat-libtool \
+		--output-file ${output}
 
-if [ ! -z "${CODECOV_TOKEN}" ]; then
-	curl -sSL https://codecov.io/bash -o ./codecov
-	chmod +x ./codecov
-
-	./codecov -s ${PROJECT_ROOT}
-else
-	echo "Skip uploading code coverage..."
+	if [ ! -z "${CODECOV_TOKEN}" ]; then
+		bash <(curl -s https://codecov.io/bash)
+	fi
 fi

--- a/beanspeak.c
+++ b/beanspeak.c
@@ -46,6 +46,7 @@ static PHP_MINIT_FUNCTION(beanspeak)
 
 	BEANSPEAK_INIT(Beanspeak_Client);
 	BEANSPEAK_INIT(Beanspeak_ExceptionInterface);
+	BEANSPEAK_INIT(Beanspeak_InvalidArgumentException);
 
 	return SUCCESS;
 }

--- a/beanspeak/client.h
+++ b/beanspeak/client.h
@@ -11,14 +11,14 @@ extern zend_class_entry *beanspeak_client_ce_ptr;
 extern zend_object_handlers beanspeak_client_handlers;
 
 typedef struct {
-	zval		socket;			/* current socket connection */
-	zval		host;			/* the beanstalkd server hostname or IP address to connect to */
-	zval		port;			/* the port of the server to connect to */
-	zval		timeout;		/* timeout in seconds when establishing the connection */
-	zval		persistent;		/* whether to make the connection persistent or not */
-	zval		usedTube;		/* current used tube */
-	zval		watchedTubes;	/* current watched tubes */
-	zend_object	zo;
+	zval			socket;			/* current socket connection */
+	zend_string*	host;			/* the beanstalkd server hostname or IP address to connect to */
+	uint16_t		port;			/* the port of the server to connect to */
+	uint32_t		timeout;		/* timeout in seconds when establishing the connection */
+	bool			persistent;		/* whether to make the connection persistent or not */
+	zend_string*	usedTube;		/* current used tube */
+	zval			watchedTubes;	/* current watched tubes */
+	zend_object		zo;
 } beanspeak_client_object_t;
 
 BEANSPEAK_INIT_CLASS(Beanspeak_Client);

--- a/beanspeak/exception.c
+++ b/beanspeak/exception.c
@@ -19,8 +19,36 @@
 #include "exception.h"
 
 zend_class_entry *beanspeak_exceptioninterface_ce_ptr;
+zend_class_entry *beanspeak_invalidargumentexception_ce_ptr;
 
-/* {{{ beanspeak_Beanspeak_Exception_init
+zend_class_entry*
+exception_ce(beanspeak_exception_type_t type)
+{
+	switch (type) {
+		default:
+		case INVALID_ARGUMENT:
+			return beanspeak_invalidargumentexception_ce_ptr;
+	}
+}
+
+zend_object*
+throw_exception(beanspeak_exception_type_t type, const char *fmt, ...)
+{
+	char *msg;
+	zend_object *exception;
+	va_list argv;
+
+	va_start(argv, fmt);
+	vspprintf(&msg, 0, fmt, argv);
+	va_end(argv);
+
+	exception = zend_throw_exception(exception_ce(type), msg, type);
+	efree(msg);
+
+	return exception;
+}
+
+/* {{{ beanspeak_Beanspeak_ExceptionInterface_init
  * Create and register 'Beanspeak\ExceptionInterface' interface. */
 BEANSPEAK_INIT_CLASS(Beanspeak_ExceptionInterface) {
 	BEANSPEAK_REGISTER_CLASS(Beanspeak, ExceptionInterface, beanspeak,
@@ -32,4 +60,14 @@ BEANSPEAK_INIT_CLASS(Beanspeak_ExceptionInterface) {
 }
 /* }}} */
 
+/* {{{ beanspeak_Beanspeak_InvalidArgumentException_init
+ * Create and register 'Beanspeak\InvalidArgumentException' class. */
+BEANSPEAK_INIT_CLASS(Beanspeak_InvalidArgumentException) {
+	BEANSPEAK_REGISTER_CLASS_EX(Beanspeak, InvalidArgumentException, beanspeak, invalidargumentexception,
+		spl_ce_InvalidArgumentException, beanspeak_exception_method_entry, 0);
 
+	zend_class_implements(beanspeak_invalidargumentexception_ce_ptr, 1, beanspeak_exceptioninterface_ce_ptr);
+
+	return SUCCESS;
+}
+/* }}} */

--- a/beanspeak/exception.c
+++ b/beanspeak/exception.c
@@ -49,9 +49,9 @@ throw_exception(beanspeak_exception_type_t type, const char *fmt, ...)
 }
 
 /* {{{ beanspeak_Beanspeak_ExceptionInterface_init
- * Create and register 'Beanspeak\ExceptionInterface' interface. */
+ * Create and register 'Beanspeak\Exception\ExceptionInterface' interface. */
 BEANSPEAK_INIT_CLASS(Beanspeak_ExceptionInterface) {
-	BEANSPEAK_REGISTER_CLASS(Beanspeak, ExceptionInterface, beanspeak,
+	BEANSPEAK_REGISTER_CLASS(Beanspeak\\Exception, ExceptionInterface, beanspeak,
 		exceptioninterface, beanspeak_exception_method_entry, ZEND_ACC_INTERFACE);
 
 	zend_class_implements(beanspeak_exceptioninterface_ce_ptr, 1, zend_ce_throwable);
@@ -61,9 +61,9 @@ BEANSPEAK_INIT_CLASS(Beanspeak_ExceptionInterface) {
 /* }}} */
 
 /* {{{ beanspeak_Beanspeak_InvalidArgumentException_init
- * Create and register 'Beanspeak\InvalidArgumentException' class. */
+ * Create and register 'Beanspeak\Exception\InvalidArgumentException' class. */
 BEANSPEAK_INIT_CLASS(Beanspeak_InvalidArgumentException) {
-	BEANSPEAK_REGISTER_CLASS_EX(Beanspeak, InvalidArgumentException, beanspeak, invalidargumentexception,
+	BEANSPEAK_REGISTER_CLASS_EX(Beanspeak\\Exception, InvalidArgumentException, beanspeak, invalidargumentexception,
 		spl_ce_InvalidArgumentException, beanspeak_exception_method_entry, 0);
 
 	zend_class_implements(beanspeak_invalidargumentexception_ce_ptr, 1, beanspeak_exceptioninterface_ce_ptr);

--- a/beanspeak/exception.h
+++ b/beanspeak/exception.h
@@ -7,9 +7,18 @@
  * file that was distributed with this source code.
  */
 
+typedef enum beanspeak_exception_type {
+	INVALID_ARGUMENT
+} beanspeak_exception_type_t;
+
 extern zend_class_entry *beanspeak_exceptioninterface_ce_ptr;
+extern zend_class_entry *beanspeak_invalidargumentexception_ce_ptr;
+
+extern zend_class_entry *exception_ce(beanspeak_exception_type_t type);
+extern zend_object *throw_exception(beanspeak_exception_type_t type, const char *fmt, ...);
 
 BEANSPEAK_INIT_CLASS(Beanspeak_ExceptionInterface);
+BEANSPEAK_INIT_CLASS(Beanspeak_InvalidArgumentException);
 
 /* {{{ beanspeak_exception_method_entry */
 BEANSPEAK_INIT_FUNCS(beanspeak_exception_method_entry) {

--- a/beanspeak/helpers.h
+++ b/beanspeak/helpers.h
@@ -45,11 +45,6 @@
 		INIT_NS_CLASS_ENTRY(ce, #ns, #cl, m);										\
 		lns## _ ##n## _ce_ptr = zend_register_internal_class_ex(&ce, pce); 			\
 		if (UNEXPECTED(!lns## _ ##n## _ce_ptr)) {									\
-			zend_error(E_ERROR, "Class '%s' registration has failed.",				\
-				ZEND_NS_NAME(#ns, #cl));											\
-			return FAILURE;															\
-		}																			\
-		if (!lns## _ ##n## _ce_ptr) {												\
 			zend_error(E_ERROR,														\
 				"Class to extend '%s' was not found when registering class '%s'.",	\
 				(pce ? ZSTR_VAL(pce->name) : "NULL"), ZEND_NS_NAME(#ns, #cl));		\

--- a/php_beanspeak.h
+++ b/php_beanspeak.h
@@ -12,6 +12,23 @@
 
 # include <Zend/zend_modules.h>
 
+# ifndef HAVE_STDINT_H
+typedef __int16 int16_t;
+typedef unsigned __int16 int16_t;
+typedef __int32 int32_t;
+typedef unsigned __int32 uint32_t;
+typedef __int64 int64_t;
+typedef unsigned __int64 uint64_t;
+# else
+#  include <stdint.h>
+# endif
+
+# ifdef HAVE_STDBOOL_H
+#  include <stdbool.h>
+# else
+typedef enum {false = 0, true = 1} bool;
+# endif
+
 # include "beanspeak/helpers.h"
 
 extern zend_module_entry beanspeak_module_entry;

--- a/tests/001-exception-interface.phpt
+++ b/tests/001-exception-interface.phpt
@@ -4,7 +4,7 @@ Check for Beanspeak\ExceptionInterface parent interface
 <?php include('skipif.inc'); ?>
 --FILE--
 <?php
-use Beanspeak\ExceptionInterface;
+use Beanspeak\Exception\ExceptionInterface;
 class MyImpl extends \Exception implements ExceptionInterface {}
 $ex = new MyImpl();
 var_dump($ex instanceof \Throwable);

--- a/tests/002-client-construct.phpt
+++ b/tests/002-client-construct.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Should throw expected exception on invalid Beanspeak\Client constrictor params
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php new Beanspeak\Client([]); ?>
+--EXPECTF--
+Fatal error: Uncaught TypeError: Argument 1 passed to Beanspeak\Client::__construct() must be of the type string or null, array given in %s:%d
+Stack trace:
+#0 %s(%d): Beanspeak\Client->__construct(Array)
+#1 {main}
+  thrown in %s on line %d

--- a/tests/003-client-construct.phpt
+++ b/tests/003-client-construct.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Should throw expected exception on corrupted DSN
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php new Beanspeak\Client('tcp://'); ?>
+--EXPECTF--
+Fatal error: Uncaught Beanspeak\InvalidArgumentException: The beanstalkd connection DSN is invalid: 'tcp://'. in %s:%d
+Stack trace:
+#0 %s(%d): Beanspeak\Client->__construct('tcp://')
+#1 {main}
+  thrown in %s on line %d

--- a/tests/003-client-construct.phpt
+++ b/tests/003-client-construct.phpt
@@ -5,7 +5,7 @@ Should throw expected exception on corrupted DSN
 --FILE--
 <?php new Beanspeak\Client('tcp://'); ?>
 --EXPECTF--
-Fatal error: Uncaught Beanspeak\InvalidArgumentException: The beanstalkd connection DSN is invalid: 'tcp://'. in %s:%d
+Fatal error: Uncaught Beanspeak\Exception\InvalidArgumentException: The beanstalkd connection DSN is invalid: 'tcp://'. in %s:%d
 Stack trace:
 #0 %s(%d): Beanspeak\Client->__construct('tcp://')
 #1 {main}

--- a/tests/004-client-construct.phpt
+++ b/tests/004-client-construct.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Should throw expected exception for disabled protocol
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php new Beanspeak\Client('unix://var'); ?>
+--EXPECTF--
+Fatal error: Uncaught Beanspeak\InvalidArgumentException: Protocol 'unix' currently disabled in Beanspeak Client. in %s:%d
+Stack trace:
+#0 %s(%d): Beanspeak\Client->__construct('unix://var')
+#1 {main}
+  thrown in %s on line %d

--- a/tests/004-client-construct.phpt
+++ b/tests/004-client-construct.phpt
@@ -5,7 +5,7 @@ Should throw expected exception for disabled protocol
 --FILE--
 <?php new Beanspeak\Client('unix://var'); ?>
 --EXPECTF--
-Fatal error: Uncaught Beanspeak\InvalidArgumentException: Protocol 'unix' currently disabled in Beanspeak Client. in %s:%d
+Fatal error: Uncaught Beanspeak\Exception\InvalidArgumentException: Protocol 'unix' currently disabled in Beanspeak Client. in %s:%d
 Stack trace:
 #0 %s(%d): Beanspeak\Client->__construct('unix://var')
 #1 {main}

--- a/tests/005-client-construct.phpt
+++ b/tests/005-client-construct.phpt
@@ -5,7 +5,7 @@ Should throw expected exception for invalid scheme
 --FILE--
 <?php new Beanspeak\Client('ftp://127.0.0.1'); ?>
 --EXPECTF--
-Fatal error: Uncaught Beanspeak\InvalidArgumentException: Invalid DSN scheme. Supported schemes are either 'tcp' or 'unix' (disabled), got 'ftp'. in %s:%d
+Fatal error: Uncaught Beanspeak\Exception\InvalidArgumentException: Invalid DSN scheme. Supported schemes are either 'tcp' or 'unix' (disabled), got 'ftp'. in %s:%d
 Stack trace:
 #0 %s(%d): Beanspeak\Client->__construct('ftp://127.0.0.1')
 #1 {main}

--- a/tests/005-client-construct.phpt
+++ b/tests/005-client-construct.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Should throw expected exception for invalid scheme
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php new Beanspeak\Client('ftp://127.0.0.1'); ?>
+--EXPECTF--
+Fatal error: Uncaught Beanspeak\InvalidArgumentException: Invalid DSN scheme. Supported schemes are either 'tcp' or 'unix' (disabled), got 'ftp'. in %s:%d
+Stack trace:
+#0 %s(%d): Beanspeak\Client->__construct('ftp://127.0.0.1')
+#1 {main}
+  thrown in %s on line %d

--- a/tests/006-client-construct.phpt
+++ b/tests/006-client-construct.phpt
@@ -5,7 +5,7 @@ Should throw expected exception on host absence
 --FILE--
 <?php new Beanspeak\Client('?foo=bar'); ?>
 --EXPECTF--
-Fatal error: Uncaught Beanspeak\InvalidArgumentException: Invalid Client DSN scheme: missed host part. in %s:%d
+Fatal error: Uncaught Beanspeak\Exception\InvalidArgumentException: Invalid Client DSN scheme: missed host part. in %s:%d
 Stack trace:
 #0 %s(%d): Beanspeak\Client->__construct('?foo=bar')
 #1 {main}

--- a/tests/006-client-construct.phpt
+++ b/tests/006-client-construct.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Should throw expected exception on host absence
+--SKIPIF--
+<?php include('skipif.inc'); ?>
+--FILE--
+<?php new Beanspeak\Client('?foo=bar'); ?>
+--EXPECTF--
+Fatal error: Uncaught Beanspeak\InvalidArgumentException: Invalid Client DSN scheme: missed host part. in %s:%d
+Stack trace:
+#0 %s(%d): Beanspeak\Client->__construct('?foo=bar')
+#1 {main}
+  thrown in %s on line %d

--- a/tests/101-client-construct.phpt
+++ b/tests/101-client-construct.phpt
@@ -1,12 +1,23 @@
 --TEST--
-Should throw exception on invalid Beanspeak\Client constrictor params
+Should create a Beanspeak\Client instance with default params
 --SKIPIF--
 <?php include('skipif.inc'); ?>
 --FILE--
-<?php new Beanspeak\Client([]); ?>
---EXPECTF--
-Fatal error: Uncaught TypeError: Argument 1 passed to Beanspeak\Client::__construct() must be of the type string or null, array given in %s:%d
-Stack trace:
-#0 %s(%d): Beanspeak\Client->__construct(Array)
-#1 {main}
-  thrown in %s on line %d
+<?php
+$cl = new Beanspeak\Client();
+$reflect = new ReflectionObject($cl);
+foreach ($reflect->getProperties() as $prop) {
+    echo implode(' ', Reflection::getModifierNames($prop->getModifiers())) . " \${$prop->getName()} = ";
+    echo $prop->setAccessible(true);
+    echo $prop->getValue($cl) == null ? 'NULL' : $prop->getValue($cl);
+    echo ";\n";
+}
+?>
+--EXPECT--
+private $socket = NULL;
+private $host = 127.0.0.1;
+private $port = 11300;
+private $timeout = 60;
+private $persistent = 1;
+protected $usedTube = default;
+protected $watchedTubes = NULL;

--- a/tests/102-client-construct.phpt
+++ b/tests/102-client-construct.phpt
@@ -1,23 +1,26 @@
 --TEST--
-Should create a Beanspeak\Client instance with default params
+Should create a Beanspeak\Client instance with provided params
 --SKIPIF--
 <?php include('skipif.inc'); ?>
 --FILE--
 <?php
-$cl = new Beanspeak\Client();
-$reflect = new ReflectionObject($cl);
-foreach ($reflect->getProperties() as $prop) {
-    echo implode(' ', Reflection::getModifierNames($prop->getModifiers())) . " \${$prop->getName()} = ";
-    echo $prop->setAccessible(true);
-    echo $prop->getValue($cl) == null ? 'NULL' : $prop->getValue($cl);
-    echo ";\n";
-}
+$cl = new Beanspeak\Client('128.7.6.5');
+$reflect = new ReflectionClass(Beanspeak\Client::class);
+$prop = $reflect->getProperty('host');
+$prop->setAccessible(true);
+var_dump($prop->getValue($cl));
+
+$cl = new Beanspeak\Client('192.169.0.1:299');
+$reflect = new ReflectionClass(Beanspeak\Client::class);
+$host = $reflect->getProperty('host');
+$port = $reflect->getProperty('port');
+$host->setAccessible(true);
+$port->setAccessible(true);
+var_dump($host->getValue($cl));
+var_dump($port->getValue($cl));
+
 ?>
 --EXPECT--
-private $socket = NULL;
-private $host = 127.0.0.1;
-private $port = 11300;
-private $timeout = 60;
-private $persistent = 1;
-protected $usedTube = default;
-protected $watchedTubes = NULL;
+string(9) "128.7.6.5"
+string(11) "192.169.0.1"
+int(299)


### PR DESCRIPTION
- Moved exceptions to the common place

- Added
```php
class Beanspeak\Exception\InvalidArgumentException
    extends \InvalidArgumentException
    implements \Beanspeak\Exception\ExceptionInterface
```

- Throw InvalidArgumentException on invalid parameters passed to the Client